### PR TITLE
Parameterize upload with blob access tier

### DIFF
--- a/examples/read_seas5_cogs.md
+++ b/examples/read_seas5_cogs.md
@@ -8,7 +8,7 @@ jupyter:
       format_version: '1.3'
       jupytext_version: 1.16.3
   kernelspec:
-    display_name: venv
+    display_name: Python 3 (ipykernel)
     language: python
     name: python3
 ---
@@ -48,7 +48,7 @@ dev_rst_container_client = ContainerClient.from_container_url(DEV_BLOB_GLB_URL)
 Start by getting all the blob names from 2000
 
 ```python
-YEAR = 2001
+YEAR = 2002
 
 blob_names = existing_files = [
     x.name
@@ -104,5 +104,5 @@ ds
 For example, here is the forecast published in Jan 2001, for the following month (February, leadtime of 1):
 
 ```python
-ds.sel({"date": "2001-01-01", "leadtime": 1}).plot()
+ds.sel({"date": "2002-01-01", "leadtime": 1}).plot()
 ```

--- a/src/seas5/aws_tprate.py
+++ b/src/seas5/aws_tprate.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import fsspec
 import xarray as xr
+from azure.storage.blob import StandardBlobTier
 from dotenv import load_dotenv
 
 from constants import CONTAINER_RASTER
@@ -97,6 +98,8 @@ def process_aws(month, lt_month, path_raw, dir, mode="local"):
             container_name=CONTAINER_RASTER,
             local_file_path=path_processed,
             blob_path=processed_outpath,
+            content_type="image/tiff",
+            blob_tier=StandardBlobTier.HOT,
         )
     return
 

--- a/src/seas5/mars_tprate.py
+++ b/src/seas5/mars_tprate.py
@@ -150,6 +150,7 @@ def process_archive(path_raw, dir, mode="local"):
                     container_name=CONTAINER_RASTER,
                     local_file_path=path_processed,
                     blob_path=processed_outpath,
+                    content_type="image/tiff",
                     blob_tier=StandardBlobTier.HOT,
                 )
     logger.info("Files processed successfully.")

--- a/src/seas5/mars_tprate.py
+++ b/src/seas5/mars_tprate.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import pandas as pd
 import xarray as xr
+from azure.storage.blob import StandardBlobTier
 from ecmwfapi import ECMWFService
 
 from constants import (
@@ -165,6 +166,7 @@ def process_archive(path_raw, dir, mode="local"):
                     container_name=CONTAINER_RASTER,
                     storage_account=storage_account,
                     blob_path=processed_outpath,
+                    blob_tier=StandardBlobTier.HOT,
                 )
     logger.info("Files processed successfully.")
     return

--- a/src/utils/cloud_utils.py
+++ b/src/utils/cloud_utils.py
@@ -1,7 +1,14 @@
-from azure.storage.blob import BlobClient
+from azure.storage.blob import BlobClient, StandardBlobTier
 
 
-def upload_file(sas_token, container_name, storage_account, local_file_path, blob_path):
+def upload_file(
+    sas_token,
+    container_name,
+    storage_account,
+    local_file_path,
+    blob_path,
+    blob_tier=StandardBlobTier.COOL,
+):
     """
     Uploads a single file from 'local_file_path'
     to 'blob_path' in Azure Blob Storage.
@@ -11,4 +18,4 @@ def upload_file(sas_token, container_name, storage_account, local_file_path, blo
 
     blob_client = BlobClient.from_blob_url(blob_url=sas_url)
     with open(local_file_path, "rb") as data:
-        blob_client.upload_blob(data, overwrite=True)
+        blob_client.upload_blob(data, overwrite=True, standard_blob_tier=blob_tier)

--- a/src/utils/cloud_utils.py
+++ b/src/utils/cloud_utils.py
@@ -15,7 +15,7 @@ def upload_file(
     local_file_path,
     blob_path,
     blob_tier=StandardBlobTier.COOL,
-    content_type="image/tiff",
+    content_type="application/octet-stream",
 ):
     """
     Uploads a single file from 'local_file_path'

--- a/src/utils/cloud_utils.py
+++ b/src/utils/cloud_utils.py
@@ -1,4 +1,4 @@
-from azure.storage.blob import BlobClient, StandardBlobTier
+from azure.storage.blob import BlobClient, ContentSettings, StandardBlobTier
 
 
 def upload_file(
@@ -8,6 +8,7 @@ def upload_file(
     local_file_path,
     blob_path,
     blob_tier=StandardBlobTier.COOL,
+    content_type="image/tiff",
 ):
     """
     Uploads a single file from 'local_file_path'
@@ -18,4 +19,9 @@ def upload_file(
 
     blob_client = BlobClient.from_blob_url(blob_url=sas_url)
     with open(local_file_path, "rb") as data:
-        blob_client.upload_blob(data, overwrite=True, standard_blob_tier=blob_tier)
+        blob_client.upload_blob(
+            data,
+            overwrite=True,
+            standard_blob_tier=blob_tier,
+            content_settings=ContentSettings(content_type=content_type),
+        )


### PR DESCRIPTION
Minor change to enable us to set the [access tier](https://learn.microsoft.com/en-us/azure/storage/blobs/access-tiers-overview) for blobs. As discussed, all data under `raw/` should be `COOL` and all data under `processed/` should be `HOT`. Also set the content type for blobs to `image/tiff` by default. 

I tested these outputs with some of the MARS data and everything seems to be working well. There's not much discernible difference in performance or output structure, but these options should be more correct long term. 