### PR TITLE
Adding some error handling for missing urls

### DIFF
--- a/run_imerg.py
+++ b/run_imerg.py
@@ -43,13 +43,14 @@ if __name__ == "__main__":
                 output_dir=output_dir,
                 mode=args.mode,
             )
-            tp_processed = imerg.process_nc4(
-                date=date,
-                run=args.run,
-                version=args.version,
-                output_dir=tp_raw,
-                mode=args.mode,
-            )
+            if tp_raw:
+                tp_processed = imerg.process_nc4(
+                    date=date,
+                    run=args.run,
+                    version=args.version,
+                    output_dir=tp_raw,
+                    mode=args.mode,
+                )
     else:
         logger.info(
             f"Running in '{args.mode}' mode. Saving data to {args.mode} Azure storage."
@@ -67,13 +68,14 @@ if __name__ == "__main__":
                     output_dir=td,
                     mode=args.mode,
                 )
-                tp_processed = imerg.process_nc4(
-                    date=date,
-                    run=args.run,
-                    version=args.version,
-                    path_raw=tp_raw,
-                    output_dir=td,
-                    mode=args.mode,
-                )
+                if tp_raw:
+                    tp_processed = imerg.process_nc4(
+                        date=date,
+                        run=args.run,
+                        version=args.version,
+                        path_raw=tp_raw,
+                        output_dir=td,
+                        mode=args.mode,
+                    )
 
     logger.info("Finished running pipeline.")

--- a/src/imerg/imerg.py
+++ b/src/imerg/imerg.py
@@ -54,8 +54,13 @@ def download(
     url = IMERG_BASE_URL.format(
         run=run, date=date, version=version, version_letter=version_letter
     )
-    result = requests.get(url)
-    result.raise_for_status()
+
+    try:
+        result = requests.get(url)
+        result.raise_for_status()
+    except requests.exceptions.HTTPError as err:
+        logger.error(f"Failed downloading: {err}")
+        return None
 
     f = open(path_raw, "wb")
     f.write(result.content)


### PR DESCRIPTION
There is a gap Jan 1 2024 to June 1 2024 in the IMERG data so this addresses failure when trying to retrieve urls that don't exist.