### PR TITLE
Add a directory with temporal aggregation to all outputs

### DIFF
--- a/src/config/imerg_config.yml
+++ b/src/config/imerg_config.yml
@@ -1,6 +1,6 @@
 container_name: raster
-raw_path: "imerg/v7/{run_type}/raw"
-processed_path: "imerg/v7/{run_type}/processed"
+raw_path: "imerg/daily/{run_type}/v7/raw"
+processed_path: "imerg/daily/{run_type}/v7/processed"
 base_url: "https://gpm1.gesdisc.eosdis.nasa.gov/data/GPM_L3/GPM_3IMERGD{run}.0{version}/{date:%Y}/{date:%m}/3B-DAY-{run}.MS.MRG.3IMERG.{date:%Y%m%d}-S000000-E235959.V0{version}{version_letter}.nc4"
 metadata:
   units: mm/day

--- a/src/config/seas5_config.yml
+++ b/src/config/seas5_config.yml
@@ -1,6 +1,6 @@
 container_name: raster
-raw_path: seas5/raw
-processed_path: seas5/processed
+raw_path: seas5/monthly/raw
+processed_path: seas5/monthly/processed
 bbox:
   dev: [60, 29, 75, 38]
   prod: [-180, -90, 180, 90]


### PR DESCRIPTION
Following discussion on Slack, as we'll likely want to have other datasets from the same source with different temporal aggregations. 

This is relatively hard-coded for now, but we can configure this as a parameter in the future. 