### PR TITLE
Check coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,10 @@ Atmospheric and Environmental Research (AER) [FloodScan's](https://www.aer.com/w
 temporarily flooded and unflooded areas from satellite remote sensing observations. See this [Technical Spec ](https://www.aer.com/siteassets/files/floodscan_data_users_guide_v05r01_r03.pdf) for more details.
 
 </details>
+
 ## Usage
 
-All pipelines can be run as a CLI, via the `run_pipeline.py` entrypoint. For detailed usage instructions and options, see our [Pipeline Usage Guide](docs/USAGE.md).
+All pipelines can be run as a CLI, via the `run_pipeline.py` entrypoint. For detailed usage instructions and options, see our [Pipeline Usage Guide](docs/usage.md).
 
 Pipelines are run in production as [Jobs on Databricks](https://docs.databricks.com/en/jobs/create-run-jobs.html). Please reach out if you require access.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -17,18 +17,19 @@ These options are available for both pipelines:
 - `--mode {local,dev,prod}`: Specify the mode to run the pipeline in (default: local)
 - `--log-level {DEBUG,INFO,WARNING,ERROR,CRITICAL}`: Set the logging level (default: INFO)
 - `--use-cache`: Use cached raw data if available
+- `--backfill`: Check for missing dates and backfill if necessary
 
 ## ERA5 Options
 
 - `--start-year YEAR`: Start year for data processing. Min 1981.
 - `--end-year YEAR`: End year for data processing. Max 2024.
-- `--update`: Run in update mode (fetches only the data from last month)
+- `--update`: Get data from **last month** if available
 
 ## SEAS5 Options
 
 - `--start-year YEAR`: Start year for data processing. Min 1981.
 - `--end-year YEAR`: End year for data processing. Max 2024.
-- `--update`: Run in update mode (fetches only the data from last month)
+- `--update`: Get data from **this month** if available
 
 ## IMERG Options
 
@@ -43,8 +44,8 @@ These options are available for both pipelines:
 - `--start-date DATE`, `-s DATE`: Start date to retrieve and process FloodScan data (format: YYYY-MM-DD, default: yesterday)
 - `--end-date DATE`, `-e DATE`: End date to retrieve and process FloodScan data (format: YYYY-MM-DD, default: yesterday)
 - `--version {5}`, `-v {5}`: FloodScan version to use (5 is the only one supported at the moment)
-- `--update`: Run update for yesterday if available
--
+- `--update`: Get data from **yesterday** if available
+
 ## Examples
 
 1. Run ERA5 pipeline in local mode for years 2020-2022:
@@ -57,9 +58,9 @@ These options are available for both pipelines:
    python run_pipeline.py seas5 --mode dev --start-year 2020 --end-year 2022 --use-cache
    ```
 
-3. Update ERA5 data in production mode:
+3. Update ERA5 data in production mode and backfill for missing dates:
    ```
-   python run_pipeline.py era5 --mode prod --update
+   python run_pipeline.py era5 --mode prod --update --backfill
    ```
 
 4. Run IMERG pipeline to get yesterday's data and save in production storage:
@@ -71,4 +72,5 @@ These options are available for both pipelines:
    ```
    python run_pipeline.py floodscan --mode prod --update
    ```
+
 Note: Ensure you have set up the necessary environment variables and dependencies before running the pipelines.

--- a/src/config/era5_config.yml
+++ b/src/config/era5_config.yml
@@ -1,6 +1,10 @@
 container_name: raster
 raw_path: era5/monthly/raw
 processed_path: era5/monthly/processed
+coverage:
+  start_date: 1981-01-01
+  end_date: Null
+  frequency: M
 metadata:
   units: mm/day
   averaging_period: monthly

--- a/src/config/floodscan_config.yml
+++ b/src/config/floodscan_config.yml
@@ -3,6 +3,10 @@ raw_path: "floodscan/daily/v5/raw"
 processed_path: "floodscan/daily/v5/processed"
 sfed_historical : "aer_sfed_area_300s_19980112_20231231_v05r01.nc"
 mfed_historical : "aer_mfed_area_300s_19980112_20231231_v05r01.nc"
+coverage:
+  start_date: 1998-01-12
+  end_date: Null
+  frequency: D
 metadata:
   units: Flood fraction
   averaging_period: daily

--- a/src/config/imerg_config.yml
+++ b/src/config/imerg_config.yml
@@ -2,6 +2,10 @@ container_name: raster
 raw_path: "imerg/daily/{run_type}/v7/raw"
 processed_path: "imerg/daily/{run_type}/v7/processed"
 base_url: "https://gpm1.gesdisc.eosdis.nasa.gov/data/GPM_L3/GPM_3IMERGD{run}.0{version}/{date:%Y}/{date:%m}/3B-DAY-{run}.MS.MRG.3IMERG.{date:%Y%m%d}-S000000-E235959.V0{version}{version_letter}.nc4"
+coverage:
+  start_date: 2000-06-01
+  end_date: Null
+  frequency: D
 metadata:
   units: mm/day
   averaging_period: daily

--- a/src/config/seas5_config.yml
+++ b/src/config/seas5_config.yml
@@ -5,6 +5,10 @@ bbox:
   dev: [60, 29, 75, 38]
   prod: [-180, -90, 180, 90]
   local: [60, 29, 75, 38]
+coverage:
+  start_date: 1981-01-01
+  end_date: Null
+  frequency: M
 metadata:
   units: mm/day
   averaging_period: monthly

--- a/src/pipelines/era5_pipeline.py
+++ b/src/pipelines/era5_pipeline.py
@@ -94,12 +94,6 @@ class ERA5Pipeline(Pipeline):
 
         self.logger.info(f"Running ERA5 pipeline in {self.mode} mode...")
 
-        # Run for the latest available date
-        if self.is_update:
-            self.logger.info("Retrieving ERA5 data from last month...")
-            raw_filename = self.get_raw_data(year=cur_year, month=last_month)
-            self.process_data(raw_filename)
-
         if self.backfill:
             self.logger.info("Checking for missing data and backfilling if needed...")
             missing_dates, coverage_pct = self.check_coverage()
@@ -111,6 +105,12 @@ class ERA5Pipeline(Pipeline):
                         year=missing_date.year, month=missing_date.month
                     )
                     self.process_data(raw_filename)
+
+        # Run for the latest available date
+        if self.is_update:
+            self.logger.info("Retrieving ERA5 data from last month...")
+            raw_filename = self.get_raw_data(year=cur_year, month=last_month)
+            self.process_data(raw_filename)
 
         else:
             self.logger.info(

--- a/src/pipelines/era5_pipeline.py
+++ b/src/pipelines/era5_pipeline.py
@@ -98,7 +98,7 @@ class ERA5Pipeline(Pipeline):
             self.logger.info("Checking for missing data and backfilling if needed...")
             missing_dates, coverage_pct = self.check_coverage()
             self.print_coverage_report()
-            if coverage_pct != 100:
+            if missing_dates:
                 for missing_date in missing_dates:
                     self.logger.debug(f"Getting data for {missing_date}...")
                     raw_filename = self.get_raw_data(

--- a/src/pipelines/era5_pipeline.py
+++ b/src/pipelines/era5_pipeline.py
@@ -18,6 +18,7 @@ class ERA5Pipeline(Pipeline):
             log_level=log_level,
             mode=mode,
             metadata=kwargs["metadata"],
+            coverage=kwargs["coverage"],
             use_cache=kwargs["use_cache"],
         )
         self.is_update = is_update

--- a/src/pipelines/floodscan_pipeline.py
+++ b/src/pipelines/floodscan_pipeline.py
@@ -34,6 +34,7 @@ class FloodScanPipeline(Pipeline):
             log_level=kwargs["log_level"],
             mode=kwargs["mode"],
             metadata=kwargs["metadata"],
+            coverage=kwargs["coverage"],
             use_cache=kwargs["use_cache"],
         )
 
@@ -205,7 +206,6 @@ class FloodScanPipeline(Pipeline):
             self.logger.error(f"Failed to extract: {e}")
 
     def process_historical_data(self, filepath, date, band_type):
-
         self.logger.info(f"Processing historical {band_type} data from {date}")
 
         with xr.open_dataset(filepath) as ds:
@@ -251,7 +251,6 @@ class FloodScanPipeline(Pipeline):
                 )
 
         unzipped_files = list(zip(unzipped_sfed, unzipped_mfed))
-
 
         for file in unzipped_files:
             date = get_datetime_from_filename(file[0])

--- a/src/pipelines/imerg_pipeline.py
+++ b/src/pipelines/imerg_pipeline.py
@@ -25,6 +25,7 @@ class IMERGPipeline(Pipeline):
             log_level=kwargs["log_level"],
             mode=kwargs["mode"],
             metadata=kwargs["metadata"],
+            coverage=kwargs["coverage"],
             use_cache=kwargs["use_cache"],
         )
 

--- a/src/pipelines/imerg_pipeline.py
+++ b/src/pipelines/imerg_pipeline.py
@@ -136,7 +136,7 @@ class IMERGPipeline(Pipeline):
             self.logger.info("Checking for missing data and backfilling if needed...")
             missing_dates, coverage_pct = self.check_coverage()
             self.print_coverage_report()
-            if coverage_pct != 100:
+            if missing_dates:
                 for missing_date in missing_dates:
                     # TODO: Repeated with below...
                     self.logger.debug(f"Getting data for {missing_date}...")

--- a/src/pipelines/pipeline.py
+++ b/src/pipelines/pipeline.py
@@ -202,6 +202,8 @@ class Pipeline(ABC):
         expected_dates = pd.date_range(
             start=start_date, end=end_date, freq="MS" if frequency == "M" else frequency
         )
+        # Drop the last one -- ie. current month or current year isn't missing
+        expected_dates = expected_dates[:-1]
         existing_dates = self._get_existing_dates()
 
         missing_dates = [date for date in expected_dates if date not in existing_dates]
@@ -265,6 +267,7 @@ class Pipeline(ABC):
             except AttributeError as e:
                 da = ds
                 self.logger.warning(f"Input data is already a DataArray: {e}")
+        # TODO: Hard coded
         if len(da.attrs) != 15:
             da.attrs = self.metadata
         if not validate_dataset(da, filename):

--- a/src/pipelines/seas5_pipeline.py
+++ b/src/pipelines/seas5_pipeline.py
@@ -182,7 +182,7 @@ class SEAS5Pipeline(Pipeline):
             self.logger.info("Checking for missing data and backfilling if needed...")
             missing_dates, coverage_pct = self.check_coverage()
             self.print_coverage_report()
-            if coverage_pct != 100:
+            if missing_dates:
                 for missing_date in missing_dates:
                     self.logger.debug(f"Getting data for {missing_date}...")
                     missing_month = missing_date.month

--- a/src/pipelines/seas5_pipeline.py
+++ b/src/pipelines/seas5_pipeline.py
@@ -178,17 +178,6 @@ class SEAS5Pipeline(Pipeline):
 
         self.logger.info(f"Running SEAS5 pipeline in {self.mode} mode...")
 
-        # Run for the latest available date
-        if self.is_update:
-            self.logger.info("Retrieving SEAS5 data from this month...")
-            for fc_month in leadtime_utils.leadtime_months(this_month, 7):
-                raw_filename = self.get_raw_data(
-                    year=cur_year, issued_month=this_month, fc_month=fc_month
-                )
-                self.process_data(
-                    raw_filename, cur_year, issued_month=this_month, fc_month=fc_month
-                )
-
         if self.backfill:
             self.logger.info("Checking for missing data and backfilling if needed...")
             missing_dates, coverage_pct = self.check_coverage()
@@ -211,6 +200,16 @@ class SEAS5Pipeline(Pipeline):
                             fc_month=fc_month,
                         )
 
+        # Run for the latest available date
+        if self.is_update:
+            self.logger.info("Retrieving SEAS5 data from this month...")
+            for fc_month in leadtime_utils.leadtime_months(this_month, 7):
+                raw_filename = self.get_raw_data(
+                    year=cur_year, issued_month=this_month, fc_month=fc_month
+                )
+                self.process_data(
+                    raw_filename, cur_year, issued_month=this_month, fc_month=fc_month
+                )
         else:
             self.logger.info(
                 f"Retrieving SEAS5 data from {self.start_year} to {self.end_year}..."

--- a/src/pipelines/seas5_pipeline.py
+++ b/src/pipelines/seas5_pipeline.py
@@ -22,6 +22,7 @@ class SEAS5Pipeline(Pipeline):
             coverage=kwargs["coverage"],
             use_cache=kwargs["use_cache"],
         )
+        self.backfill = kwargs["backfill"]
         self.is_update = is_update
         self.start_year = start_year
         self.end_year = end_year
@@ -176,6 +177,8 @@ class SEAS5Pipeline(Pipeline):
         this_month = today.month
 
         self.logger.info(f"Running SEAS5 pipeline in {self.mode} mode...")
+
+        # Run for the latest available date
         if self.is_update:
             self.logger.info("Retrieving SEAS5 data from this month...")
             for fc_month in leadtime_utils.leadtime_months(this_month, 7):
@@ -185,6 +188,28 @@ class SEAS5Pipeline(Pipeline):
                 self.process_data(
                     raw_filename, cur_year, issued_month=this_month, fc_month=fc_month
                 )
+
+        if self.backfill:
+            self.logger.info("Checking for missing data and backfilling if needed...")
+            missing_dates, coverage_pct = self.check_coverage()
+            self.print_coverage_report()
+            if coverage_pct != 100:
+                for missing_date in missing_dates:
+                    self.logger.debug(f"Getting data for {missing_date}...")
+                    missing_month = missing_date.month
+                    missing_year = missing_date.year
+                    for fc_month in leadtime_utils.leadtime_months(missing_month, 7):
+                        raw_filename = self.get_raw_data(
+                            year=missing_year,
+                            issued_month=missing_month,
+                            fc_month=fc_month,
+                        )
+                        self.process_data(
+                            raw_filename,
+                            missing_year,
+                            issued_month=missing_month,
+                            fc_month=fc_month,
+                        )
 
         else:
             self.logger.info(

--- a/src/pipelines/seas5_pipeline.py
+++ b/src/pipelines/seas5_pipeline.py
@@ -19,6 +19,7 @@ class SEAS5Pipeline(Pipeline):
             log_level=log_level,
             mode=mode,
             metadata=kwargs["metadata"],
+            coverage=kwargs["coverage"],
             use_cache=kwargs["use_cache"],
         )
         self.is_update = is_update

--- a/src/scripts/run_era5_pipeline.py
+++ b/src/scripts/run_era5_pipeline.py
@@ -13,6 +13,11 @@ def parse_arguments(base_parser):
         "--end-year", type=int, required=False, help="End year for data processing"
     )
     parser.add_argument("--update", action="store_true", help="Run in update mode")
+    parser.add_argument(
+        "--backfill",
+        action="store_true",
+        help="Whether to check and backfill for any missing dates (only 2024 onwards)",
+    )
     return parser.parse_args()
 
 
@@ -23,6 +28,7 @@ def main(base_parser):
         {
             "mode": args.mode,
             "is_update": args.update,
+            "backfill": args.backfill,
             "start_year": args.start_year,
             "end_year": args.end_year,
             "log_level": args.log_level,
@@ -31,5 +37,4 @@ def main(base_parser):
     )
 
     pipeline = ERA5Pipeline(**settings)
-    # pipeline.run_pipeline()
-    pipeline.print_coverage_report()
+    pipeline.run_pipeline()

--- a/src/scripts/run_era5_pipeline.py
+++ b/src/scripts/run_era5_pipeline.py
@@ -31,4 +31,5 @@ def main(base_parser):
     )
 
     pipeline = ERA5Pipeline(**settings)
-    pipeline.run_pipeline()
+    # pipeline.run_pipeline()
+    pipeline.print_coverage_report()

--- a/src/scripts/run_imerg_pipeline.py
+++ b/src/scripts/run_imerg_pipeline.py
@@ -49,6 +49,11 @@ def parse_arguments(base_parser):
         help="Create authorization files for accessing IMERG datasets",
         action="store_true",
     )
+    parser.add_argument(
+        "--backfill",
+        action="store_true",
+        help="Whether to check and backfill for any missing dates (only 2024 onwards)",
+    )
     return parser.parse_args()
 
 
@@ -62,6 +67,7 @@ def main(base_parser):
             "end_date": args.end_date,
             "log_level": args.log_level,
             "use_cache": args.use_cache,
+            "backfill": args.backfill,
             "version": args.version,
             "run": args.run,
             "create_auth_files": args.create_auth_files,
@@ -69,5 +75,4 @@ def main(base_parser):
     )
 
     pipeline = IMERGPipeline(**settings)
-    # pipeline.run_pipeline()
-    pipeline.print_coverage_report()
+    pipeline.run_pipeline()

--- a/src/scripts/run_imerg_pipeline.py
+++ b/src/scripts/run_imerg_pipeline.py
@@ -69,4 +69,5 @@ def main(base_parser):
     )
 
     pipeline = IMERGPipeline(**settings)
-    pipeline.run_pipeline()
+    # pipeline.run_pipeline()
+    pipeline.print_coverage_report()

--- a/src/scripts/run_seas5_pipeline.py
+++ b/src/scripts/run_seas5_pipeline.py
@@ -12,6 +12,11 @@ def parse_arguments(base_parser):
     parser.add_argument(
         "--end-year", type=int, required=False, help="End year for data processing"
     )
+    parser.add_argument(
+        "--backfill",
+        action="store_true",
+        help="Whether to check and backfill for any missing dates (only 2024 onwards)",
+    )
     parser.add_argument("--update", action="store_true", help="Run in update mode")
     return parser.parse_args()
 
@@ -23,6 +28,7 @@ def main(base_parser):
         {
             "mode": args.mode,
             "is_update": args.update,
+            "backfill": args.backfill,
             "start_year": args.start_year,
             "end_year": args.end_year,
             "log_level": args.log_level,
@@ -31,5 +37,4 @@ def main(base_parser):
     )
 
     pipeline = SEAS5Pipeline(**settings)
-    # pipeline.run_pipeline()
-    pipeline.print_coverage_report()
+    pipeline.run_pipeline()

--- a/src/scripts/run_seas5_pipeline.py
+++ b/src/scripts/run_seas5_pipeline.py
@@ -31,4 +31,5 @@ def main(base_parser):
     )
 
     pipeline = SEAS5Pipeline(**settings)
-    pipeline.run_pipeline()
+    # pipeline.run_pipeline()
+    pipeline.print_coverage_report()

--- a/tests/test_era5_pipeline.py
+++ b/tests/test_era5_pipeline.py
@@ -19,7 +19,7 @@ def pipeline(monkeypatch):
         raw_path="test-raw",
         processed_path="test-processed",
         use_cache=False,
-        backfill=True,
+        backfill=False,
         metadata={},
         coverage={},
     )

--- a/tests/test_era5_pipeline.py
+++ b/tests/test_era5_pipeline.py
@@ -19,7 +19,9 @@ def pipeline(monkeypatch):
         raw_path="test-raw",
         processed_path="test-processed",
         use_cache=False,
+        backfill=True,
         metadata={},
+        coverage={},
     )
 
 


### PR DESCRIPTION
Addressing #5 for all datasets except Floodscan. As discussed with @isatotun, will address for Floodscan in a separate PR.

Across all pipelines, adding `--backfill` will run a check across all dates in the range specified in the `coverage` section of each dataset's `config.yml` file. This flag will also download to fill in any missing dates. 

I've implemented some core functionality in the `Pipeline` class, and have had to do some set up in the child dataset-specific classes. I'm not super happy with the code repetition across datasets here, as this would ideally be entirely core to `Pipeline`. BUT, there would need to be some significant refactoring to make this happen (especially in `FloodscanPipeline`), which I don't think is worth it at this stage.

I've run this backfilling on `prod` for the datasets below. Not ideal to go straight there, but I'm not sure how best to run in `dev`, as we don't need to keep a full historical record there (so backfilling would download more data than we need). I thought about setting a `dev` coverage section of the `.yaml` files, but don't love the complexity that this adds. I think fine for now. 

- [x] SEAS5
- [x] ERA5
- [x] IMERG