### PR TITLE
Floodscan backfilling

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -17,7 +17,7 @@ These options are available for both pipelines:
 - `--mode {local,dev,prod}`: Specify the mode to run the pipeline in (default: local)
 - `--log-level {DEBUG,INFO,WARNING,ERROR,CRITICAL}`: Set the logging level (default: INFO)
 - `--use-cache`: Use cached raw data if available
-- `--backfill`: Check for missing dates and backfill if necessary
+- `--backfill`: Check for missing dates and backfill if necessary (only for 2024 dates onwards)
 
 ## ERA5 Options
 

--- a/examples/floodscan_testing.md
+++ b/examples/floodscan_testing.md
@@ -1,0 +1,246 @@
+---
+jupyter:
+  jupytext:
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.3'
+      jupytext_version: 1.16.3
+  kernelspec:
+    display_name: venv
+    language: python
+    name: python3
+---
+
+## Floodscan Pipeline testing
+
+This notebook runs through some basic testing for data updates with the `FloodscanPipeline`. All outputs are saved locally. Running this notebook will empty any local processed Flooscan COGs.
+
+```python
+%load_ext autoreload
+%autoreload 2
+```
+
+Load Floodscan config and dependencies
+
+```python
+from datetime import datetime, timedelta
+from src.pipelines.floodscan_pipeline import FloodScanPipeline
+from dotenv import load_dotenv
+from src.config.settings import load_pipeline_config
+from src.utils.azure_utils import blob_client, download_from_azure
+import os
+import glob
+
+load_dotenv()
+
+settings = load_pipeline_config("floodscan")
+```
+
+Set up an instance of the class. Note: Starting in `local` mode
+
+```python
+settings.update(
+    {
+        "mode": "local",
+        "is_update": True,
+        "backfill": True,
+        "start_date": "2024-01-01",
+        "end_date": "2024-01-02",
+        "version": 5,
+        "log_level": "INFO",
+        "use_cache": False, # NOTE: Bug if use_cache: True
+    }
+)
+
+floodscan = FloodScanPipeline(**settings)
+```
+
+Set up expected local directory with raw files
+
+```python
+blob = blob_client("dev")
+
+sfed_local_file_path = floodscan.local_raw_dir / floodscan.sfed_historical
+mfed_local_file_path = floodscan.local_raw_dir / floodscan.mfed_historical
+
+# Download the pre-2024 files
+download_from_azure(
+    blob_service_client=blob,
+    container_name=floodscan.container_name,
+    blob_path=floodscan.raw_path / floodscan.sfed_historical,
+    local_file_path=sfed_local_file_path,
+)
+
+download_from_azure(
+    blob_service_client=blob,
+    container_name=floodscan.container_name,
+    blob_path=floodscan.raw_path / floodscan.mfed_historical,
+    local_file_path=mfed_local_file_path,
+)
+
+# Download the zip files
+sfed_dates = [datetime(2024,2, 26), datetime(2024,2, 28)]
+mfed_dates = [datetime(2024,2, 26), datetime(2024,2, 27), datetime(2024,2, 28)]
+
+for date in sfed_dates:
+    raw_filename = floodscan._generate_raw_filename(date, "SFED")
+    download_from_azure(
+        blob_service_client=blob,
+        container_name=floodscan.container_name,
+        blob_path=floodscan.raw_path / raw_filename,
+        local_file_path=floodscan.local_raw_dir / raw_filename,
+    )
+
+for date in mfed_dates:
+    raw_filename = floodscan._generate_raw_filename(date, "MFED")
+    download_from_azure(
+        blob_service_client=blob,
+        container_name=floodscan.container_name,
+        blob_path=floodscan.raw_path / raw_filename,
+        local_file_path=floodscan.local_raw_dir / raw_filename,
+    )
+```
+
+```python
+def check_and_clean_directory(valid_dates, just_clean=False):
+    raw_dir = floodscan.local_processed_dir
+    expected_filenames = {f'aer_area_300s_v{date.strftime('%Y-%m-%d')}_v05r01.tif' for date in valid_dates}
+    all_files = set(os.path.basename(f) for f in glob.glob(os.path.join(raw_dir, '*.tif')))
+
+    if not just_clean:
+        # Check if files match exactly with expected files
+        if all_files != expected_filenames:
+            extra_files = all_files - expected_filenames
+            missing_files = expected_filenames - all_files
+
+            error_msg = []
+            if extra_files:
+                error_msg.append(f"Unexpected files found: {extra_files}")
+            if missing_files:
+                error_msg.append(f"Missing expected files: {missing_files}")
+
+            raise AssertionError(" | ".join(error_msg))
+
+    # If we get here, the assertion passed, now remove all files
+    for file in all_files:
+        full_path = os.path.join(raw_dir, file)
+        os.remove(full_path)
+        print(f"Removed: {full_path}")
+```
+
+```python
+check_and_clean_directory([], just_clean=True)
+```
+
+## Testing basic functionality
+
+**Test 1**: Run latest update
+
+```python
+floodscan.process_latest_update()
+
+# Check and cleanup
+yesterday = (datetime.now() - timedelta(days=1)).date()
+check_and_clean_directory([yesterday])
+```
+
+**Test 2**: Process single historical date where we have both SFED and MFED raw files present
+
+```python
+test_date = [datetime(2024,2, 26)]
+floodscan.process_historical_dates(test_date)
+
+check_and_clean_directory(test_date)
+```
+
+**Test 3**: Process single historical date where only MFED raw file present, but has raw file from within the preceeding 90 days
+
+```python
+test_date = [datetime(2024,2, 27)]
+floodscan.process_historical_dates(test_date)
+
+check_and_clean_directory(test_date)
+```
+
+**Test 4**: Processing single historical date where no raw file present, and no raw file from within the preceeding 90 days
+
+```python
+test_date = [datetime(2024,3, 27)]
+floodscan.process_historical_dates(test_date)
+
+check_and_clean_directory([]) # No data updates! Should this error instead?
+```
+
+**Test 5**: Process single historical date from before 2024 (so pulling from NetCDF file)
+
+```python
+test_date = [datetime(2023,1, 27)]
+floodscan.process_historical_dates(test_date)
+
+check_and_clean_directory(test_date)
+```
+
+**Test 6**: Process multiple historical dates, which have a mix of the above conditions
+
+```python
+test_dates = [
+    datetime(2023, 1, 25),  # Pre 2024
+    datetime(2024, 1, 25),  # Raw file in preceeding 90 days
+    datetime(2024, 2, 25),  # Raw file in preceeding 90 days
+    datetime(2024, 2, 26),  # All there
+    datetime(2024, 2, 27),  # Only mfed
+    datetime(2024, 2, 28),  # All there
+]
+floodscan.process_historical_dates(test_dates)
+
+check_and_clean_directory(test_dates)
+```
+
+**Test 7**: Print coverage report
+
+```python
+floodscan.print_coverage_report()
+```
+
+## End to end tests
+
+**Test 1**: Basic daily update, without any backfilling
+
+```python
+settings.update({"is_update": True, "backfill": False})
+floodscan = FloodScanPipeline(**settings)
+floodscan.run_pipeline()
+```
+
+**Test 2**: Basic daily update, with backfilling
+
+```python
+settings.update({"is_update": True, "backfill": True})
+floodscan = FloodScanPipeline(**settings)
+floodscan.run_pipeline()
+```
+
+**Test 3**: Test historical update, between two dates in 2024
+
+```python
+settings.update({"start_date": "2024-02-26","end_date": "2024-02-28", "backfill": False, "is_update": False})
+floodscan = FloodScanPipeline(**settings)
+floodscan.run_pipeline()
+```
+
+**Test 4**: Test historical update, between two dates in 2023
+
+```python
+settings.update({"start_date": "2023-02-26","end_date": "2023-02-28"})
+floodscan = FloodScanPipeline(**settings)
+floodscan.run_pipeline()
+```
+
+**Test 5**: Test historical update, between two dates that span 2023 and 2024
+
+```python
+settings.update({"start_date": "2023-12-26","end_date": "2024-01-05", "is_update": False})
+floodscan = FloodScanPipeline(**settings)
+floodscan.run_pipeline()
+```

--- a/src/pipelines/floodscan_pipeline.py
+++ b/src/pipelines/floodscan_pipeline.py
@@ -425,6 +425,7 @@ class FloodScanPipeline(Pipeline):
         sfed_da = self.process_data(sfed, band_type=SFED)
         mdfed_da = self.process_data(mfed, band_type=MFED)
         self._combine_bands(sfed_da, mdfed_da, latest_date)
+        self._cleanup_local()
         return True
 
     def run_pipeline(self):

--- a/src/pipelines/floodscan_pipeline.py
+++ b/src/pipelines/floodscan_pipeline.py
@@ -240,17 +240,11 @@ class FloodScanPipeline(Pipeline):
                 f"Unzipping data from from {filepath[SFED]} and {filepath[MFED]} to {self.local_raw_dir}"
             )
 
-            # try:
             unzipped_sfed += self._unzip_90days_file(filepath[SFED], dates)
             unzipped_mfed += self._unzip_90days_file(filepath[MFED], dates)
 
             if len(dates) == len(unzipped_sfed):
                 break
-            # except Exception as err:
-            #     print(err)
-            #     self.logger.error(
-            #         f"Failed to extract {filepath[SFED]} or {filepath[MFED]}: {err}"
-            #     )
 
         unzipped_files = list(zip(unzipped_sfed, unzipped_mfed))
 

--- a/src/pipelines/floodscan_pipeline.py
+++ b/src/pipelines/floodscan_pipeline.py
@@ -103,7 +103,7 @@ class FloodScanPipeline(Pipeline):
             pairs.setdefault(date, set()).add(file_type)
         return sorted([date for date, types in pairs.items() if len(types) == 2])
 
-    def _get_90_days_filenames_for_dates(self, dates, max_days=5):
+    def _get_90_days_filenames_for_dates(self, dates, max_days=90):
         """
         Given an input list of dates, this function returns a list of the
         raw filenames associated with SFED and MFED data for each date. If no
@@ -126,7 +126,6 @@ class FloodScanPipeline(Pipeline):
                 if f.startswith("aer_floodscan")
             ]
         available_dates = self._get_dates_with_pairs(existing_files)
-        print(f"The following dates have zipped data: {available_dates}")
 
         filenames = []
         for target in dates:

--- a/src/pipelines/floodscan_pipeline.py
+++ b/src/pipelines/floodscan_pipeline.py
@@ -139,7 +139,7 @@ class FloodScanPipeline(Pipeline):
                 )
                 continue
 
-            # Check next 5 days
+            # Check next 90 days
             found = False
             for days in range(1, max_days + 1):
                 future_date = target + timedelta(days=days)
@@ -154,7 +154,7 @@ class FloodScanPipeline(Pipeline):
                     break
 
             if not found:
-                self.logger.warning(
+                self.logger.error(
                     f"No available data within {max_days} days of {target}"
                 )
 
@@ -249,10 +249,11 @@ class FloodScanPipeline(Pipeline):
 
         for file in unzipped_files:
             date = get_datetime_from_filename(file[0])
-            self.logger.info(f"Processing historical {SFED} data from {date}")
+            date_pretty = date.strftime("%Y-%m-%d")
+            self.logger.info(f"Processing historical {SFED} data from {date_pretty}")
             sfed_da = self.process_data(file[0], band_type=SFED)
 
-            self.logger.info(f"Processing historical {MFED} data from {date}")
+            self.logger.info(f"Processing historical {MFED} data from {date_pretty}")
             mfed_da = self.process_data(file[1], band_type=MFED)
             self._combine_bands(sfed_da, mfed_da, date=date)
 
@@ -329,7 +330,8 @@ class FloodScanPipeline(Pipeline):
             return sfed_unzipped, mfed_unzipped, latest_date
 
     def process_historical_data(self, filepath, date, band_type):
-        self.logger.info(f"Processing historical {band_type} data from {date}")
+        date_pretty = date.strftime("%Y-%m-%d")
+        self.logger.info(f"Processing historical {band_type} data from {date_pretty}")
 
         with xr.open_dataset(filepath) as ds:
             ds = ds.transpose("time", "lat", "lon")

--- a/src/pipelines/pipeline.py
+++ b/src/pipelines/pipeline.py
@@ -246,7 +246,7 @@ class Pipeline(ABC):
         self.logger.info(f"Overall coverage: {coverage_pct:.1f}%")
 
         if missing_dates:
-            self.logger.info("Missing Dates after 2024:")
+            self.logger.info(f"Missing dates after 2024 ({len(missing_dates)} total):")
             for date in missing_dates:
                 self.logger.info(f" - {date.strftime('%Y-%m-%d')}")
         else:

--- a/src/pipelines/pipeline.py
+++ b/src/pipelines/pipeline.py
@@ -221,7 +221,7 @@ class Pipeline(ABC):
         ]
         if pre_2024_dates:
             self.logger.warning(
-                f"There are {len(pre_2024_dates)} missing from before 2024. These won't be backfilled automatically."
+                f"There are {len(pre_2024_dates)} files missing from before 2024. These won't be backfilled automatically."  # noqa
             )
 
         coverage_pct = (len(existing_dates) / len(expected_dates)) * 100

--- a/src/scripts/run_floodscan_pipeline.py
+++ b/src/scripts/run_floodscan_pipeline.py
@@ -36,6 +36,11 @@ def parse_arguments(base_parser):
         choices=[5],
         default=5,
     )
+    parser.add_argument(
+        "--backfill",
+        action="store_true",
+        help="Whether to check and backfill for any missing dates (only 2024 onwards)",
+    )
     parser.add_argument("--update", action="store_true", help="Run in update mode")
     return parser.parse_args()
 
@@ -56,4 +61,5 @@ def main(base_parser):
     )
 
     pipeline = FloodScanPipeline(**settings)
-    pipeline.run_pipeline()
+    # pipeline.run_pipeline()
+    pipeline.print_coverage_report()

--- a/src/scripts/run_floodscan_pipeline.py
+++ b/src/scripts/run_floodscan_pipeline.py
@@ -52,6 +52,7 @@ def main(base_parser):
         {
             "mode": args.mode,
             "is_update": args.update,
+            "backfill": args.backfill,
             "start_date": args.start_date,
             "end_date": args.end_date,
             "version": args.version,
@@ -61,5 +62,5 @@ def main(base_parser):
     )
 
     pipeline = FloodScanPipeline(**settings)
-    # pipeline.run_pipeline()
-    pipeline.print_coverage_report()
+    pipeline.run_pipeline()
+    # pipeline.print_coverage_report()


### PR DESCRIPTION
Enable the `--backfill` argument for the Floodscan pipeline. Have added in some minor refactoring to address bugs and improve legibility of some functions. The majority of changes are in the `_get_90_days_filenames_for_dates` function, which I've rewritten. I've also refactored the `self.run_pipeline` method so that it accepts a list of generic dates as input and runs updates accordingly. 

I've also suggested removing some of the general `try/except` blocks, as I found that during development these were quite challenging to debug (eg. a lot of error messages were the same) and could hide a lot of errors happening.

The `floodscan_testing.md` notebook is a helpful walkthrough to validate these changes -- please run through and let me know if any errors. 