### PR TITLE
Updated floodscan backfilling

### DIFF
--- a/src/config/floodscan_config.yml
+++ b/src/config/floodscan_config.yml
@@ -4,7 +4,7 @@ processed_path: "floodscan/daily/v5/processed"
 sfed_historical : "aer_sfed_area_300s_19980112_20231231_v05r01.nc"
 mfed_historical : "aer_mfed_area_300s_19980112_20231231_v05r01.nc"
 coverage:
-  start_date: 1998-01-12
+  start_date: 2025-01-01
   end_date: Null
   frequency: D
 metadata:

--- a/src/config/floodscan_config.yml
+++ b/src/config/floodscan_config.yml
@@ -4,7 +4,7 @@ processed_path: "floodscan/daily/v5/processed"
 sfed_historical : "aer_sfed_area_300s_19980112_20231231_v05r01.nc"
 mfed_historical : "aer_mfed_area_300s_19980112_20231231_v05r01.nc"
 coverage:
-  start_date: 2025-01-01
+  start_date: 1998-01-12
   end_date: Null
   frequency: D
 metadata:

--- a/src/pipelines/floodscan_pipeline.py
+++ b/src/pipelines/floodscan_pipeline.py
@@ -294,6 +294,8 @@ class FloodScanPipeline(Pipeline):
         else:
             return self.local_raw_dir / raw_filename
 
+    # TODO: Fix file naming reference for zip file to be according to the
+    # latest file inside the zip (revert to as it was before)
     def query_api(self, date):
         # The zipped file should be labelled for yesterday's date
         yesterday = datetime.today() - pd.DateOffset(days=1)

--- a/src/pipelines/floodscan_pipeline.py
+++ b/src/pipelines/floodscan_pipeline.py
@@ -295,10 +295,7 @@ class FloodScanPipeline(Pipeline):
         else:
             return self.local_raw_dir / raw_filename
 
-    # TODO: Fix file naming reference for zip file to be according to the
-    # latest file inside the zip (revert to as it was before)
     def query_api(self, date):
-        # The zipped file should be labelled for yesterday's date
         yesterday = datetime.today() - pd.DateOffset(days=1)
         sfed_raw_filename = self._generate_raw_filename(yesterday, SFED)
         mfed_raw_filename = self._generate_raw_filename(yesterday, MFED)

--- a/src/pipelines/floodscan_pipeline.py
+++ b/src/pipelines/floodscan_pipeline.py
@@ -41,6 +41,7 @@ class FloodScanPipeline(Pipeline):
         self.start_date = datetime.strptime(kwargs["start_date"], DATE_FORMAT)
         self.end_date = datetime.strptime(kwargs["end_date"], DATE_FORMAT)
         self.is_update = kwargs["is_update"]
+        self.backfill = kwargs["backfill"]
         self.version = kwargs["version"]
         self.sfed_historical = kwargs["sfed_historical"]
         self.mfed_historical = kwargs["mfed_historical"]
@@ -53,19 +54,24 @@ class FloodScanPipeline(Pipeline):
     def _generate_processed_filename(self, date):
         return f"aer_area_300s_v{date.strftime(DATE_FORMAT)}_v0{self.version}r01.tif"
 
-    def get_most_recent_geotiff_from_daily_90_days_file(self, filepath):
+    def get_geotiff_from_daily_90_days_file(self, filepath, date):
         with ZipFile(filepath, "r") as zipobj:
             filenames = zipobj.namelist()
-            latest = max(filenames)
-            self.logger.info(f"Most recent geotiff in this file is: {latest}")
-            try:
-                full_path = zipobj.extract(latest, os.path.dirname(filepath))
-                tif_filename = os.path.basename(
-                    shutil.move(full_path, os.path.dirname(filepath))
-                )
-                return tif_filename
-            except Exception as e:
-                self.logger.info(f"Failed to extract {latest}: {e}")
+            for file in filenames:
+                if file.endswith(".tif"):
+                    file_date = get_datetime_from_filename(file).date()
+                    if file_date == date:
+                        self.logger.info(f"Geotiff from {date} is present: {file}")
+                        try:
+                            full_path = zipobj.extract(file, os.path.dirname(filepath))
+                            tif_filename = os.path.basename(
+                                shutil.move(full_path, os.path.dirname(filepath))
+                            )
+                            return tif_filename
+                        except Exception as e:
+                            self.logger.info(f"Failed to extract {file}: {e}")
+                        break
+            self.logger.warning(f"Geotiff from {date} not present")
 
     def get_historical_nc_files(self):
         sfed_local_file_path = self.local_raw_dir / self.sfed_historical
@@ -289,49 +295,40 @@ class FloodScanPipeline(Pipeline):
             return self.local_raw_dir / raw_filename
 
     def query_api(self, date):
-        today = datetime.today()
-        yesterday = today - pd.DateOffset(days=1)
-
         sfed_raw_filename = self._generate_raw_filename(date, SFED)
         mfed_raw_filename = self._generate_raw_filename(date, MFED)
 
-        # Gets the latest 90 days zip files for SFED and MFED
-        if date.date() == yesterday.date():
-            try:
-                sfed_result = requests.get(self.sfed_base_url)
-                mfed_result = requests.get(self.mfed_base_url)
-                sfed_result.raise_for_status()
-                mfed_result.raise_for_status()
-            except requests.exceptions.HTTPError as err:
-                self.logger.error(f"Failed downloading: {err}")
-                return None
+        try:
+            sfed_result = requests.get(self.sfed_base_url)
+            mfed_result = requests.get(self.mfed_base_url)
+            sfed_result.raise_for_status()
+            mfed_result.raise_for_status()
+        except requests.exceptions.HTTPError as err:
+            self.logger.error(f"Failed downloading: {err}")
+            return None
 
-            sfed_filepath = self.local_raw_dir / sfed_raw_filename
-            with open(sfed_filepath, "wb") as sfed:
-                sfed.write(sfed_result.content)
+        sfed_filepath = self.local_raw_dir / sfed_raw_filename
+        with open(sfed_filepath, "wb") as sfed:
+            sfed.write(sfed_result.content)
 
-            mfed_filepath = self.local_raw_dir / mfed_raw_filename
-            with open(mfed_filepath, "wb") as mfed:
-                mfed.write(mfed_result.content)
+        mfed_filepath = self.local_raw_dir / mfed_raw_filename
+        with open(mfed_filepath, "wb") as mfed:
+            mfed.write(mfed_result.content)
 
-            sfed_unzipped, mfed_unzipped = (
-                self.get_most_recent_geotiff_from_daily_90_days_file(sfed_filepath),
-                self.get_most_recent_geotiff_from_daily_90_days_file(mfed_filepath),
-            )
-            latest_date = get_datetime_from_filename(sfed_unzipped)
+        sfed_unzipped, mfed_unzipped = (
+            self.get_geotiff_from_daily_90_days_file(sfed_filepath, date),
+            self.get_geotiff_from_daily_90_days_file(mfed_filepath, date),
+        )
+        latest_date = get_datetime_from_filename(sfed_unzipped)
 
-            sfed_raw_path = self._update_name_if_necessary(
-                sfed_filepath, SFED, latest_date
-            )
-            mfed_raw_path = self._update_name_if_necessary(
-                mfed_filepath, MFED, latest_date
-            )
+        sfed_raw_path = self._update_name_if_necessary(sfed_filepath, SFED, latest_date)
+        mfed_raw_path = self._update_name_if_necessary(mfed_filepath, MFED, latest_date)
 
-            # Saving the latest zipped files for SFED and MFED
-            self.save_raw_data(os.path.basename(sfed_raw_path))
-            self.save_raw_data(os.path.basename(mfed_raw_path))
+        # Saving the latest zipped files for SFED and MFED
+        self.save_raw_data(os.path.basename(sfed_raw_path))
+        self.save_raw_data(os.path.basename(mfed_raw_path))
 
-            return sfed_unzipped, mfed_unzipped, latest_date
+        return sfed_unzipped, mfed_unzipped, latest_date
 
     def process_data(self, filename, band_type, date=None):
         if not date:
@@ -376,10 +373,22 @@ class FloodScanPipeline(Pipeline):
 
         self.logger.info(f"Running FloodScan pipeline in {self.mode} mode...")
 
+        # This assumes that all missing dates will be in the last 90 days
+        if self.backfill:
+            self.logger.info("Checking for missing data and backfilling if needed...")
+            missing_dates, _ = self.check_coverage()
+            self.print_coverage_report()
+            for date in missing_dates:
+                sfed, mfed, latest_date = self.get_raw_data(date=yesterday.date())
+                sfed_da = self.process_data(sfed, band_type=SFED)
+                mdfed_da = self.process_data(mfed, band_type=MFED)
+                self.combine_bands(sfed_da, mdfed_da, latest_date)
+                self._cleanup_local()
+
         # Run for the latest available date
         if self.is_update:
             self.logger.info("Retrieving FloodScan data from yesterday...")
-            sfed, mfed, latest_date = self.get_raw_data(date=yesterday)
+            sfed, mfed, latest_date = self.get_raw_data(date=yesterday.date())
             sfed_da = self.process_data(sfed, band_type=SFED)
             mdfed_da = self.process_data(mfed, band_type=MFED)
             self.combine_bands(sfed_da, mdfed_da, latest_date)

--- a/src/pipelines/pipeline.py
+++ b/src/pipelines/pipeline.py
@@ -229,9 +229,10 @@ class Pipeline(ABC):
         self.logger.info(f"Coverage: {coverage_pct:.1f}%")
 
         if missing_dates:
-            self.logger.info("Missing Dates:")
-            for date in missing_dates:
-                self.logger.info(f" - {date.strftime('%Y-%m-%d')}")
+            self.logger.info(f"Missing Dates: {len(missing_dates)}")
+            if len(missing_dates) < 10:
+                for date in missing_dates:
+                    self.logger.info(f" - {date.strftime('%Y-%m-%d')}")
         else:
             self.logger.info("No missing dates found!")
 

--- a/src/pipelines/pipeline.py
+++ b/src/pipelines/pipeline.py
@@ -202,8 +202,9 @@ class Pipeline(ABC):
         expected_dates = pd.date_range(
             start=start_date, end=end_date, freq="MS" if frequency == "M" else frequency
         )
-        # Drop the last one -- ie. current month or current year isn't missing
-        expected_dates = expected_dates[:-1]
+        # Drop the last two -- ie. current month or current year isn't missing
+        # as well as the latest update date
+        expected_dates = expected_dates[:-2]
         existing_dates = self._get_existing_dates()
 
         missing_dates = [date for date in expected_dates if date not in existing_dates]

--- a/src/scripts/run_floodscan_pipeline.py
+++ b/src/scripts/run_floodscan_pipeline.py
@@ -36,6 +36,11 @@ def parse_arguments(base_parser):
         choices=[5],
         default=5,
     )
+    parser.add_argument(
+        "--backfill",
+        action="store_true",
+        help="Whether to check and backfill for any missing dates (only 2024 onwards)",
+    )
     parser.add_argument("--update", action="store_true", help="Run in update mode")
     return parser.parse_args()
 
@@ -47,6 +52,7 @@ def main(base_parser):
         {
             "mode": args.mode,
             "is_update": args.update,
+            "backfill": args.backfill,
             "start_date": args.start_date,
             "end_date": args.end_date,
             "version": args.version,


### PR DESCRIPTION
This PR replaces #66 as a simpler approach to backfilling in any missing dates. We assume that all missing dates can be backfilled by the latest 90-days file (which is currently true for `prod`). 

This PR primarily changes the `query_api` function to more fully handle the `date` input argument, by passing it to the modified `get_geotiff_from_90_days_file()` function. The backfilling will rerun `query_api()` for each missing date, which redownloads and unzips the latest 90 days file each time. Note this this will be highly inefficient if we have many missing dates -- it seems unlikely that this will ever be the case, but this is something to be aware of. 