### PR TITLE
Repair affine 3.x breakage that has Run IMERG failing since Aug 8

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -1,10 +1,38 @@
-import argparse
-import sys
+# TEMPORARY (2026-08-12): repair affine 3.x on the Databricks job
+# clusters. affine 3.0.0 (released 2026-08-08) is an attrs slots-class
+# that needs a modern attrs to make functools.cached_property work
+# without an instance __dict__; the clusters' preinstalled attrs is too
+# old for that, so every Affine.__getitem__ raises TypeError ("No
+# '__dict__' attribute on 'Affine' instance") — the Run IMERG job has
+# failed daily since 2026-08-08 because of this. The jobs' library
+# lists leave affine floating, so the workaround lives here: when the
+# probe shows affine is broken, downgrade its cached_property members
+# to plain (uncached) properties. No-op when affine is healthy. Remove
+# once the job configs pin affine==2.4.0.
+import functools
 
-from src.scripts.run_era5_pipeline import main as run_era5
-from src.scripts.run_floodscan_pipeline import main as run_floodscan
-from src.scripts.run_imerg_pipeline import main as run_imerg
-from src.scripts.run_seas5_pipeline import main as run_seas5
+import affine
+
+
+def _repair_affine() -> None:
+    try:
+        affine.Affine.identity()[0]
+    except TypeError:
+        for _name, _member in list(vars(affine.Affine).items()):
+            if isinstance(_member, functools.cached_property):
+                setattr(affine.Affine, _name, property(_member.func))
+        affine.Affine.identity()[0]  # fail loudly if still broken
+
+
+_repair_affine()
+
+import argparse  # noqa: E402
+import sys  # noqa: E402
+
+from src.scripts.run_era5_pipeline import main as run_era5  # noqa: E402
+from src.scripts.run_floodscan_pipeline import main as run_floodscan  # noqa: E402
+from src.scripts.run_imerg_pipeline import main as run_imerg  # noqa: E402
+from src.scripts.run_seas5_pipeline import main as run_seas5  # noqa: E402
 
 
 def create_base_parser():


### PR DESCRIPTION
## Problem

The **Run IMERG** Databricks job (666239885322861) has failed on every daily run since **2026-08-08** (last success Aug 7):

```
TypeError: No '__dict__' attribute on 'Affine' instance to cache '_astuple' property.
```

`public.imerg` is stale at **2026-08-06** — this feeds the Haiti hurricane AA framework's observational rainfall trigger, so we'd like it green again before peak season.

## Root cause

- `affine 3.0.0` was released **2026-08-08**, the day the failures started. It's an attrs slots-class that needs a modern `attrs` for `functools.cached_property` to work without an instance `__dict__`.
- The job clusters preinstall an older `attrs` (affine only declares an unversioned `attrs` dependency, so pip keeps the stale one), leaving broken descriptors: any `Affine.__getitem__` / slicing raises the TypeError above, via `rioxarray .rio.to_raster()` → `.rio.transform()`.
- The job's library list pins `rioxarray==0.16.0` but leaves the transitive `affine` floating, which is how 3.0.0 crept in.

Reproduced locally on Python 3.10 with `affine==3.0.0 attrs==22.2.0`; works with `affine==2.4.0`.

## Fix (stopgap)

The job config is workspace-managed and only its owner/admins can edit the library list, so this PR patches the entry point instead: at startup, probe affine and — only if broken — downgrade its `cached_property` members to plain uncached `property`s. No-op when affine is healthy, no runtime installs, verified against the reproduced breakage.

## Proper fix (for job owner)

Add PyPI library `affine==2.4.0` to the `download_imerg` task (and the other tasks with floating affine) in the workspace job config, then revert this commit. cc @isatotun @hannahker

The pipeline tracks missing dates itself, so the stale week should backfill on the first green run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)